### PR TITLE
Refactor to fix positioning on landscape/tablet

### DIFF
--- a/SuperBadges/Classes/SuperBadges.swift
+++ b/SuperBadges/Classes/SuperBadges.swift
@@ -1,42 +1,33 @@
 public extension UITabBarController {
-    func addDotAtTabBarItemIndex(index: Int, radius : CGFloat = 5, color : UIColor = UIColor.red, text : String? = nil) {
+    func addDotAtTabBarItemIndex(index: Int, radius: CGFloat = 5, color : UIColor = UIColor.red, text : String? = nil, xOffset: CGFloat = 0, yOffset: CGFloat = 0) {
         let tag = index + 999
-        for subview in self.tabBar.subviews {
-            if subview.tag == tag {
-                subview.removeFromSuperview()
-                break
-            }
-        }
-        let dotRadius: CGFloat = radius
-        let dotDiameter = dotRadius * 2
-        let TabBarItemCount = CGFloat(self.tabBar.items!.count)
-        let HalfItemWidth = view.bounds.width / (TabBarItemCount * 2)
-        let imageHalfWidth: CGFloat = (self.tabBar.items![index]).selectedImage!.size.width / 2
+        
+        removeDotAtTabBarItemIndex(index: index)
+        let dotDiameter = radius * 2
+        let xOffsetBase = CGFloat(21)
+        let yOffsetBase = CGFloat(3)
+        
         if text == nil {
-            let xOffset = HalfItemWidth * CGFloat(index * 2 + 1)
-            let TopMargin:CGFloat = 7
-            let dot = UIView(frame: CGRect(x: xOffset + imageHalfWidth, y: TopMargin, width: dotDiameter, height: dotDiameter))
+            let dot = UIView(frame: CGRect(x: xOffsetBase + xOffset, y: yOffsetBase + yOffset, width: dotDiameter, height: dotDiameter))
             dot.tag = tag
             dot.backgroundColor = color
-            dot.layer.cornerRadius = dotRadius
-            self.tabBar.addSubview(dot)
+            dot.layer.cornerRadius = radius
+            tabBar.subviews[index + 1].subviews.first?.insertSubview(dot, at: 1)
         } else {
-            let xOffset = HalfItemWidth * CGFloat(index * 2 + 1) - 3
-            let TopMargin:CGFloat = 3
-            let label = UILabel(frame: CGRect(x: xOffset + imageHalfWidth, y: TopMargin, width: dotDiameter, height: dotDiameter))
+            let label = UILabel(frame: CGRect(x: xOffsetBase + xOffset, y: yOffsetBase + yOffset, width: dotDiameter, height: dotDiameter))
             label.tag = tag
             label.numberOfLines = 1
             label.adjustsFontSizeToFitWidth = true
             label.minimumScaleFactor = 0.3
             label.text = text!
-            self.tabBar.addSubview(label)
+            tabBar.subviews[index + 1].subviews.first?.insertSubview(label, at: 1)
         }
     }
     
     func removeDotAtTabBarItemIndex(index: Int) {
         let tag = index + 999
-        for subview in self.tabBar.subviews {
-            if subview.tag == tag {
+        if let subviews = tabBar.subviews[index + 1].subviews.first?.subviews {
+            for subview in subviews where subview.tag == tag {
                 subview.removeFromSuperview()
             }
         }


### PR DESCRIPTION
The current implementation relies on the fact that the tab bar caption is located underneath the image, in order to position the indicator correctly (basically positioning the indicator above the complete tab bar).

This PR changes this behavior and directly attaches the indicator relative to the image view itself in order to preserve the correct positioning.